### PR TITLE
✨ Add Overview groupsubject page

### DIFF
--- a/src/Components/EntryElement/EntryElement.tsx
+++ b/src/Components/EntryElement/EntryElement.tsx
@@ -31,10 +31,18 @@ export default function EntryElement({
       <span className={styles.gap}>|</span>
       <DeleteIcon
         handleOnClick={() => {
-          if (
-            confirm(`If you want to delete ${surname} ${lastname} click "ok"!`)
-          ) {
-            deleteEntry(`https://server.manu-web.de/${category}`, id);
+          if (category === 'students' || category === 'teachers') {
+            if (
+              confirm(
+                `If you want to delete ${surname} ${lastname} click "ok"!`
+              )
+            ) {
+              deleteEntry(`https://server.manu-web.de/${category}`, id);
+            }
+          } else {
+            if (confirm(`If you want to delete ${entryname} click "ok"!`)) {
+              deleteEntry(`https://server.manu-web.de/${category}`, id);
+            }
           }
         }}
       />

--- a/src/Pages/OverviewGroupSubject/OverviewGroupSubject.module.css
+++ b/src/Pages/OverviewGroupSubject/OverviewGroupSubject.module.css
@@ -1,0 +1,9 @@
+.results {
+  display: grid;
+  margin-top: 1rem;
+  gap: 0.5rem;
+}
+
+.noResult {
+  text-align: center;
+}

--- a/src/Pages/OverviewGroupSubject/OverviewGroupSubject.stories.tsx
+++ b/src/Pages/OverviewGroupSubject/OverviewGroupSubject.stories.tsx
@@ -1,0 +1,9 @@
+import OverviewGroupSubject from './OverviewGroupSubject';
+
+export default {
+  component: OverviewGroupSubject,
+  title: 'Pages/OverviewGroupSubject',
+};
+
+export const Groups = () => <OverviewGroupSubject category={'groups'} />;
+export const Subjects = () => <OverviewGroupSubject category={'subjects'} />;

--- a/src/Pages/OverviewGroupSubject/OverviewGroupSubject.tsx
+++ b/src/Pages/OverviewGroupSubject/OverviewGroupSubject.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { GroupsType, SubjectsType } from '../../utils/types';
+import styles from './OverviewGroupSubject.module.css';
+import TitleElement from '../../Components/TitleElement/TitleElement';
+import EntryElement from '../../Components/EntryElement/EntryElement';
+import PullToRefresh from 'pulltorefreshjs';
+import { setGroupSubjectFetch } from '../../utils/helper';
+
+type OverviewSocialProps = {
+  category: 'groups' | 'subjects';
+};
+
+export default function OverviewSocial({
+  category,
+}: OverviewSocialProps): JSX.Element {
+  const [allEntries, setAllEntries] = useState<GroupsType[] | SubjectsType[]>(
+    []
+  );
+  console.log(allEntries);
+  PullToRefresh.init({
+    mainElement: 'div',
+    onRefresh() {
+      setGroupSubjectFetch(category, setAllEntries);
+    },
+  });
+
+  useEffect(() => {
+    setGroupSubjectFetch(category, setAllEntries);
+  }, []);
+  return (
+    <>
+      <TitleElement title={category} />
+      <div className={styles.results}>
+        {allEntries[0] ? (
+          allEntries.map((entry) => (
+            <EntryElement
+              key={entry.id}
+              category={category}
+              id={entry.id}
+              entryname={entry.name}
+            />
+          ))
+        ) : (
+          <span className={styles.noResult}>No entry found</span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/utils/prepareData.tsx
+++ b/src/utils/prepareData.tsx
@@ -19,9 +19,7 @@ export function prepareGenderCount(allStudents: StudentsType[]) {
 export function prepareTeachersPerSubject(allTeachers: TeachersType[]) {
   /*   console.log(allTeachers);
    */ const teachersPrepare = allTeachers
-    .flatMap((teacher) =>
-      teacher.subjects.map((subject) => subject.subjectName)
-    )
+    .flatMap((teacher) => teacher.subjects.map((subject) => subject.name))
     .reduce(
       (prev, cur) => ({ ...prev, [cur]: (prev[cur] || 0) + 1 }),
       {} as Record<string, number>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,10 +21,10 @@ export type TeachersType = {
 
 export type SubjectsType = {
   id: number;
-  subjectName: string;
+  name: string;
 };
 
 export type GroupsType = {
   id: number;
-  groupName: string;
+  name: string;
 };


### PR DESCRIPTION
# What I did
- I took the OverviewSocial page as template
- Couldn't put Students, Teachers, Groups and Subjects on one page because their structures were a little bit different. So I split them into two pages.
- Adjusted types and prepareData function to match both pages

# Design
![image](https://user-images.githubusercontent.com/89474622/144715385-82823f57-4243-4d00-afd4-6c35cc4ab73a.png)
